### PR TITLE
add absolute path option for specfilepath in report

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,14 +169,15 @@ This `Cypress.spec` object is only available since Cypress v3.0.2 (see [Cypress 
 To avoid suite title pollution in other reporters (like the great [mochawesome](https://github.com/adamgruber/mochawesome#mochawesome)), make sure that `cypress-sonarqube-reporter` is the first one in the list.
 
 ## Reporter Options
-| Name               | Type      | Default    | Description |
-| ------------------ | --------- | ---------- | ----------- |
-| `outputDir`        | `string`  | `"./dist"` | folder name for the generated SonarQube XML reports, will be automatically created if not exist |
-| `preserveSpecsDir` | `boolean` | `true`     | specify if tests folders structure should be preserved |
-| `overwrite`        | `boolean` | `false`    | specify if existing reporters could be overwritten; if `false` then an error is raised when reports already exist |
-| `prefix`           | `string`  | `""`       | file prefix for the generated SonarQube XML reports |
-| `useFullTitle`     | `boolean` | `true`     | specify if test case should combine all parent suite(s) name(s) before the test title or only the test title |
-| `titleSeparator`   | `string`  | `" - "`    | the separator used between combined parent suite(s) name(s); only used if `useFullTitle` is `true` |
+| Name                  | Type      | Default    | Description |
+| --------------------- | --------- | ---------- | ----------- |
+| `outputDir`           | `string`  | `"./dist"` | folder name for the generated SonarQube XML reports, will be automatically created if not exist |
+| `preserveSpecsDir`    | `boolean` | `true`     | specify if tests folders structure should be preserved |
+| `overwrite`           | `boolean` | `false`    | specify if existing reporters could be overwritten; if `false` then an error is raised when reports already exist |
+| `prefix`              | `string`  | `""`       | file prefix for the generated SonarQube XML reports |
+| `useFullTitle`        | `boolean` | `true`     | specify if test case should combine all parent suite(s) name(s) before the test title or only the test title |
+| `titleSeparator`      | `string`  | `" - "`    | the separator used between combined parent suite(s) name(s); only used if `useFullTitle` is `true` |
+| `useAbsoluteSpecPath` | `boolean` | `false`    | specify if the absolute path of a spec file should be written to the report |
 
 ## Issues & Enhancements
 ![GitHub issues](https://img.shields.io/github/issues-raw/BBE78/cypress-sonarqube-reporter)

--- a/src/ReporterUtils.js
+++ b/src/ReporterUtils.js
@@ -34,10 +34,16 @@ const error = (message) => {
  */
 const extractSpecFromSuite = (suite, options) => {
     const title = suite.title;
-    const tag = options.useAbsoluteSpecPath ? "[@specAbsolute: " : "[@specRelative: ";
+    const tag = "[@spec: ";
     const index = title.indexOf(tag);
     if (index > -1) {
-        return title.substring(index + tag.length, title.indexOf("]", index)).replace(/\\/g, "/");
+        let spec = JSON.parse(title.substring(index + tag.length, title.lastIndexOf("]")));
+
+        if (options.useAbsoluteSpecPath) {
+            return spec.absolute.replace(/\\/g, "/");
+        } else {
+            return spec.relative.replace(/\\/g, "/");
+        }
     } else {
         const err = `could not find spec filename from title: ${title}`;
         error(err);
@@ -52,7 +58,7 @@ const extractSpecFromSuite = (suite, options) => {
  */
 const extractTitleFromSuite = (suite) => {
     const title = suite.title;
-    const index = title.indexOf("[@specRelative:");
+    const index = title.indexOf("[@spec:");
     if (index > -1) {
         return title.substring(0, index).trim();
     } else {

--- a/src/ReporterUtils.js
+++ b/src/ReporterUtils.js
@@ -29,14 +29,15 @@ const error = (message) => {
  * Raise an error if the spec could not be extracted.
  *
  * @param {object} suite the Mocha suite
+ * @param {object} options the Reporter Options
  * @returns {string} the spec file path
  */
-const extractSpecFromSuite = (suite) => {
+const extractSpecFromSuite = (suite, options) => {
     const title = suite.title;
-    const tag = "[@spec: ";
+    const tag = options.useAbsoluteSpecPath ? "[@specAbsolute: " : "[@specRelative: ";
     const index = title.indexOf(tag);
     if (index > -1) {
-        return title.substring(index + tag.length, title.lastIndexOf("]")).replace(/\\/g, "/");
+        return title.substring(index + tag.length, title.indexOf("]", index)).replace(/\\/g, "/");
     } else {
         const err = `could not find spec filename from title: ${title}`;
         error(err);
@@ -51,7 +52,7 @@ const extractSpecFromSuite = (suite) => {
  */
 const extractTitleFromSuite = (suite) => {
     const title = suite.title;
-    const index = title.indexOf("[@spec:");
+    const index = title.indexOf("[@specRelative:");
     if (index > -1) {
         return title.substring(0, index).trim();
     } else {

--- a/src/SonarQubeCypressReporter.js
+++ b/src/SonarQubeCypressReporter.js
@@ -20,7 +20,8 @@ const defaultOptions = {
     overwrite: false,
     prefix: "",
     useFullTitle: true,
-    titleSeparator: " - "
+    titleSeparator: " - ",
+    useAbsoluteSpecPath: false
 };
 
 
@@ -67,7 +68,7 @@ class SonarQubeCypressReporter {
     traverseSuite(node, suite) {
 
         if (suite.parent && suite.parent.root) {
-            this.specFilename = extractSpecFromSuite(suite);
+            this.specFilename = extractSpecFromSuite(suite, this.options);
             suite.title = extractTitleFromSuite(suite);
             node.attribute("path", this.specFilename);
         }

--- a/src/SpecTitle.js
+++ b/src/SpecTitle.js
@@ -4,22 +4,15 @@ const specTitle = (title) => {
         if (Cypress) {
             if (Cypress.spec) {
 
-                let specRelative;
-                let specAbsolute;
-
-                if (Cypress.spec.relative) {
-                    specRelative = `[@specRelative: ${Cypress.spec.relative}]`;
-                } else {
+                if (!Cypress.spec.relative) {
                     throw `Cypress.spec.relative is not defined, Cypress.spec = ${JSON.stringify(Cypress.spec, null, 4)}`;
                 }
 
-                if (Cypress.spec.absolute) {
-                    specAbsolute = `[@specAbsolute: ${Cypress.spec.absolute}]`;
-                } else {
+                if (!Cypress.spec.absolute) {
                     throw `Cypress.spec.absolute is not defined, Cypress.spec = ${JSON.stringify(Cypress.spec, null, 4)}`;
                 }
 
-                return `${title} ${specRelative} ${specAbsolute}`;
+                return `${title} [@spec: ${JSON.stringify(Cypress.spec)}]`;
             } else {
                 throw `Cypress.spec is not defined, Cypress = ${JSON.stringify(Cypress, null, 4)}`;
             }

--- a/src/SpecTitle.js
+++ b/src/SpecTitle.js
@@ -3,11 +3,23 @@ const specTitle = (title) => {
     if (title) {
         if (Cypress) {
             if (Cypress.spec) {
+
+                let specRelative;
+                let specAbsolute;
+
                 if (Cypress.spec.relative) {
-                    return `${title} [@spec: ${Cypress.spec.relative}]`;
+                    specRelative = `[@specRelative: ${Cypress.spec.relative}]`;
                 } else {
                     throw `Cypress.spec.relative is not defined, Cypress.spec = ${JSON.stringify(Cypress.spec, null, 4)}`;
                 }
+
+                if (Cypress.spec.absolute) {
+                    specAbsolute = `[@specAbsolute: ${Cypress.spec.absolute}]`;
+                } else {
+                    throw `Cypress.spec.absolute is not defined, Cypress.spec = ${JSON.stringify(Cypress.spec, null, 4)}`;
+                }
+
+                return `${title} ${specRelative} ${specAbsolute}`;
             } else {
                 throw `Cypress.spec is not defined, Cypress = ${JSON.stringify(Cypress, null, 4)}`;
             }

--- a/test/specs/ReporterUtils.spec.js
+++ b/test/specs/ReporterUtils.spec.js
@@ -88,15 +88,28 @@ describe("Testing ReporterUtils.js", () => {
 
         it("nominal", () => {
             const result = extractSpecFromSuite({
-                title: "My title [@spec: test/Sample.spec.js]"
+                title: "My title [@specRelative: test/Sample.spec.js] [@specAbsolute: /builds/group/project/test/Sample.spec.js]"
+            }, {
+                useAbsoluteSpecPath: false
             });
             expect(result).toBe("test/Sample.spec.js");
         });
 
-        it("without spec in title", () => {
+        it("with absolute spec file option", () => {
+            const result = extractSpecFromSuite({
+                title: "My title [@specRelative: test/Sample.spec.js] [@specAbsolute: /builds/group/project/test/Sample.spec.js]"
+            }, {
+                useAbsoluteSpecPath: true
+            });
+            expect(result).toBe("/builds/group/project/test/Sample.spec.js");
+        });
+
+        it("with spec in title", () => {
             expect(() => {
                 extractSpecFromSuite({
                     title: "My title"
+                }, {
+                    useAbsoluteSpecPath: false
                 });
             }).toThrowError("could not find spec filename from title: My title");
         });
@@ -107,7 +120,7 @@ describe("Testing ReporterUtils.js", () => {
 
         it("nominal", () => {
             const result = extractTitleFromSuite({
-                title: "My title [@spec: test/Sample.spec.js]"
+                title: "My title [@specRelative: test/Sample.spec.js] [@specAbsolute: /builds/group/project/test/Sample.spec.js]"
             });
             expect(result).toBe("My title");
         });

--- a/test/specs/ReporterUtils.spec.js
+++ b/test/specs/ReporterUtils.spec.js
@@ -88,7 +88,7 @@ describe("Testing ReporterUtils.js", () => {
 
         it("nominal", () => {
             const result = extractSpecFromSuite({
-                title: "My title [@specRelative: test/Sample.spec.js] [@specAbsolute: /builds/group/project/test/Sample.spec.js]"
+                title: 'My title [@spec: {\"relative\":\"test/Sample.spec.js\",\"absolute\":\"/builds/group/project/test/Sample.spec.js\"}]'
             }, {
                 useAbsoluteSpecPath: false
             });
@@ -97,7 +97,7 @@ describe("Testing ReporterUtils.js", () => {
 
         it("with absolute spec file option", () => {
             const result = extractSpecFromSuite({
-                title: "My title [@specRelative: test/Sample.spec.js] [@specAbsolute: /builds/group/project/test/Sample.spec.js]"
+                title: "My title [@spec: {\"relative\":\"test/Sample.spec.js\",\"absolute\":\"/builds/group/project/test/Sample.spec.js\"}]"
             }, {
                 useAbsoluteSpecPath: true
             });
@@ -120,7 +120,7 @@ describe("Testing ReporterUtils.js", () => {
 
         it("nominal", () => {
             const result = extractTitleFromSuite({
-                title: "My title [@specRelative: test/Sample.spec.js] [@specAbsolute: /builds/group/project/test/Sample.spec.js]"
+                title: "My title [@spec: {\"relative\":\"test/Sample.spec.js\",\"absolute\":\"/builds/group/project/test/Sample.spec.js\"}]"
             });
             expect(result).toBe("My title");
         });

--- a/test/specs/SpecTitle.spec.js
+++ b/test/specs/SpecTitle.spec.js
@@ -20,7 +20,7 @@ describe("Testing specTitle.js", () => {
 
         test("nominal", () => {
             const result = specTitle("My title");
-            expect(result).toBe("My title [@specRelative: test/Sample.spec.js] [@specAbsolute: /builds/group/project/test/Sample.spec.js]");
+            expect(result).toBe("My title [@spec: {\"relative\":\"test/Sample.spec.js\",\"absolute\":\"/builds/group/project/test/Sample.spec.js\"}]");
         });
 
         test("with undefined", () => {

--- a/test/specs/SpecTitle.spec.js
+++ b/test/specs/SpecTitle.spec.js
@@ -8,7 +8,8 @@ describe("Testing specTitle.js", () => {
         beforeEach(() => {
             global.Cypress = {
                 spec: {
-                    relative: "test/Sample.spec.js"
+                    relative: "test/Sample.spec.js",
+                    absolute: "/builds/group/project/test/Sample.spec.js"
                 }
             };
         });
@@ -19,7 +20,7 @@ describe("Testing specTitle.js", () => {
 
         test("nominal", () => {
             const result = specTitle("My title");
-            expect(result).toBe("My title [@spec: test/Sample.spec.js]");
+            expect(result).toBe("My title [@specRelative: test/Sample.spec.js] [@specAbsolute: /builds/group/project/test/Sample.spec.js]");
         });
 
         test("with undefined", () => {
@@ -55,6 +56,17 @@ describe("Testing specTitle.js", () => {
             expect(() => {
                 specTitle("My title");
             }).toThrowError("Cypress.spec.relative is not defined, Cypress.spec = {}");
+        });
+
+        test("without Cypress.spec.absolute defined", () => {
+            global.Cypress = {
+                spec: {
+                    relative: "test/Sample.spec.js"
+                }
+            };
+            expect(() => {
+                specTitle("My title");
+            }).toThrowError("Cypress.spec.absolute is not defined, Cypress.spec = {\n    \"relative\": \"test/Sample.spec.js\"\n}");
         });
 
     });

--- a/test/specs/TestUtils.js
+++ b/test/specs/TestUtils.js
@@ -1,6 +1,7 @@
 
 const fse = require("fs-extra");
 const parser = require("fast-xml-parser");
+const rimraf = require("rimraf");
 
 
 const createFile = (path, content) => {
@@ -12,7 +13,7 @@ const readFile = (path) => {
 }
 
 const cleanOuputDir = (dir) => {
-    fse.rmdirSync(dir, { recursive: true });
+    rimraf.sync(dir);
 };
 
 const verifyReportExists = (path) => {


### PR DESCRIPTION
We needed the absolute path of the specfile in the report.xml for our SonarQube scanner. So we added this option.

best regards
Daniel D
N+P Informationssysteme GmbH