### PR TITLE
feat: support Cypress 10 and 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x, 14.x, 16.x, 18.x]
-        cypress-version: [4.x, 5.x, 6.x, 7.x, 8.x, 9.x]
+        cypress-version: [4.x, 5.x, 6.x, 7.x, 8.x, 9.x, 10.x]
       fail-fast: false
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x, 14.x, 16.x, 18.x]
-        cypress-version: [4.x, 5.x, 6.x, 7.x, 8.x, 9.x, 10.x]
+        cypress-version: [4.x, 5.x, 6.x, 7.x, 8.x, 9.x, 10.x, 11.x]
       fail-fast: false
     steps:
       - name: Checkout

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "sonarqube-scanner": "^2.8.1"
     },
     "peerDependencies": {
-        "cypress": "^9.4.1"
+        "cypress": "^9.4.1 || ^10"
     },
     "jest": {
         "collectCoverageFrom": [

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "sonarqube-scanner": "^2.8.1"
     },
     "peerDependencies": {
-        "cypress": "^9.4.1 || ^10"
+        "cypress": "^9.4.1 || ^10 || ^11"
     },
     "jest": {
         "collectCoverageFrom": [


### PR DESCRIPTION
Adds support for Cypress 10 through peer dependencies. Related to #28.

I've been using the `1.10.0` version with Cypress 10 successfully for some time now. 