### PR TITLE
fix(MergeReports): fix `fast-xml-parser` wrong usage

### DIFF
--- a/src/MergeReports.js
+++ b/src/MergeReports.js
@@ -1,5 +1,5 @@
 const fse = require('fs-extra');
-const { XMLParser} = require('fast-xml-parser');
+const { XMLParser, XMLBuilder } = require('fast-xml-parser');
 const path = require('path');
 const readdirp = require('readdirp');
 const {
@@ -51,8 +51,7 @@ const optionalChaining = (data, ...props) => {
  * @returns {Promise} with the merged report path
  */
 const writeMergedReport = (outputPath, mergedReportAsJSON) => {
-    const xmlParser = new XMLParser(XML_PARSER_OPTIONS);
-    const xml = xmlParser.parse(mergedReportAsJSON);
+    const xml = new XMLBuilder(XML_PARSER_OPTIONS).build(mergedReportAsJSON);
     const content = `<?xml version="1.0" encoding="utf-8"?>\n${xml}`;
     return new Promise((resolve, reject) => {
         const parentPath = path.dirname(outputPath);


### PR DESCRIPTION
New versions of `fast-xml-parser` has splitted reading an xml (`XMLParser` class) vs writing it (`XMLBuilder` class). 

You can find its documentation here: https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/v4/1.GettingStarted.md#how-to-use. 

Therefore, `MergeReports.js` must be updated accordingly to work the right way.